### PR TITLE
Maketitle overwrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.aux
+*.txt
+*.synctex.gz
+*.log
+abstract.pdf

--- a/abstract/abstract.tex
+++ b/abstract/abstract.tex
@@ -30,7 +30,7 @@
 
 \addaffiliation{1}{Affiliation 1}{a.b.one@affiliation1.com, ORCHID 1111111}
 \addaffiliation{2}{Affiliation 2}{a.c.two@affiliation2.com, ORCHID 2222222; 
-	a.d.three@affiliation2.com, ORCHID 3333333}
+	a.d.three@affiliation2.com, ORCID 3333333}
 
 % The following variables will be updated by the publisher, do not edit.
 \doi{XX.XXXX/XX.XXXX}

--- a/abstract/abstract.tex
+++ b/abstract/abstract.tex
@@ -4,6 +4,34 @@
 
 \begin{document}
 
+%% Titlepage variables
+
+% Title
+\title{Instructions for Preparing an Extended Abstract for Bicycle and 
+	Motorcycle Dynamics 2023}
+
+% List authors for the title. Call \addauthor{name}{affiliationID} for every 
+% author. Authors will appear in the order off calls to \addauthor. Please 
+% manually specify the correct affiliation ID and an asterisk to the 
+% corresponding author
+\addauthor{Author B. One}{1}
+\addauthor{Author C. Two}{2}
+\addauthor{Author D. Three}{2,*}
+
+% List authors with only initials for given names, displays only in footer.
+\authorfooter{One, A. B., Two, A. C., \& Three, A. D.}
+
+% List affiliations. Call /addaffiliation{id}{name}{EmailOrchidString} once for
+% every distinct institution, where id specifies the affiliation ID (ensure 
+% that this corresponds to the IDs used with \addauthor), name specifies the 
+% affiliation name, and EmailOrchidString is a string listing emails and 
+% ORCHIDs (optional) affiliated with this affiliation separating mail and 
+% ORCHID using a comma and different author credentials using a semicolon
+
+\addaffiliation{1}{Affiliation 1}{a.b.one@affiliation1.com, ORCHID 1111111}
+\addaffiliation{2}{Affiliation 2}{a.c.two@affiliation2.com, ORCHID 2222222; 
+	a.d.three@affiliation2.com, ORCHID 3333333}
+
 % The following variables will be updated by the publisher, do not edit.
 \doi{XX.XXXX/XX.XXXX}
 \year{2023}
@@ -15,54 +43,9 @@
 \issn{2667-2812}
 % End publisher variables.
 
-% List authors with only initials for given names, displays in footer.
-\authors{One, A. B., Two, A. C., \& Three, A. D.}
+%% End titlepage variables
 
-\noindent\makebox[\linewidth]{\rule{\textwidth}{1.0pt}}
-
-\begin{flushleft}
-  {\fontsize{9pt}{11pt}\selectfont%
-    % Do not edit.
-    Type of the Paper: Extended Abstract
-  }
-\end{flushleft}
-
-\begin{flushleft}
-  {\fontsize{18pt}{20pt}\selectfont%
-    % Replace with your paper title.
-    Instructions for Preparing an Extended Abstract for Bicycle and Motorcycle
-    Dynamics 2023
-  }
-\end{flushleft}
-
-\begin{flushleft}
-  {\fontsize{10}{12}\selectfont{
-    % Replace with your authors.
-    Author~B. One~\textsuperscript{1},
-    Author~C. Two~\textsuperscript{2},
-    Author~D. Three~\textsuperscript{2,*}
-  }\\}
-  \vspace{10pt}
-  {\fontsize{8pt}{10pt}\selectfont{
-    % Replace with your affiliations.
-    \textsuperscript{1} Affiliation 1; email One; ORCID One (if applicable) \\
-    \textsuperscript{2} Affiliation 2; email Two, ORCID Two (if applicable);
-    email Three, ORCID Three (if applicable) \\
-    \textsuperscript{*} corresponding author
-  }}
-\end{flushleft}
-
-\noindent\makebox[\linewidth]{\rule{\textwidth}{0.4pt}}
-
-\begin{flushleft}
-  {\fontsize{8pt}{10pt}\selectfont{
-    Name of Editor: \printeditor \\
-    Submitted: \printsubmitteddate \\
-    Accepted: \printaccepteddate \\
-    Published: \printpublisheddate \\
-    Citation: \printcitation
-  }}
-\end{flushleft}
+\maketitle
 
 \section*{Abstract:}
 Authors are requested to upload an extended abstract of two pages (including

--- a/abstract/abstract.tex
+++ b/abstract/abstract.tex
@@ -28,7 +28,7 @@
 % ORCHIDs (optional) affiliated with this affiliation separating mail and 
 % ORCHID using a comma and different author credentials using a semicolon
 
-\addaffiliation{1}{Affiliation 1}{a.b.one@affiliation1.com, ORCHID 1111111}
+\addaffiliation{1}{Affiliation 1}{a.b.one@affiliation1.com, ORCID 1111111}
 \addaffiliation{2}{Affiliation 2}{a.c.two@affiliation2.com, ORCHID 2222222; 
 	a.d.three@affiliation2.com, ORCID 3333333}
 

--- a/abstract/bmd2023a.cls
+++ b/abstract/bmd2023a.cls
@@ -79,32 +79,32 @@
 \addtolength{\c@pwidth}{-2\t@bindwidth}
 
 \long\def\@makecaption#1#2{
-	%\vskip 10pt
-	\vskip 0.5ex
-	\iftablecap                           % Is it a table?
-	\setbox\@tempboxa\hbox{#2}
-	\ifdim \wd\@tempboxa > \c@pwidth      % IF longer than one line-2cm:
-	\hbox to\hsize{\hfil{\sc #1}\hfil}
-	\begin{list}{}{\leftmargin\t@bindwidth
-			\rightmargin\t@bindwidth}
-		{\item \footnotesize  #2}
-	\end{list}
-	\else                               % ELSE  center.
-	\hbox to\hsize{\hfil{\sc #1}\hfil}
-	\hbox to\hsize{\hfil{\footnotesize #2}\hfil}
-	\fi                                   % of \ifdim
-	\else                                 % Not a table: a picture
-	\setbox\@tempboxa\hbox{\small{\bf #1}. #2}
-	\ifdim \wd\@tempboxa >\c@pwidth       % IF longer than one line-2cm:
-	\begin{list}{}{\leftmargin\t@bindwidth
-			\rightmargin\t@bindwidth}
-		{\small \item {\bf #1}. #2}
-	\end{list}                        % THEN set as ordinary paragraph.
-	\else                               % ELSE  center.
-	\hbox to\hsize{\hfil\box\@tempboxa\hfil}
-	\fi                                   % of \ifdim
-	\fi                                   % of \if\tablecaptrue
-}                                     % \@makecaption
+   %\vskip 10pt
+   \vskip 0.5ex
+   \iftablecap                           % Is it a table?
+     \setbox\@tempboxa\hbox{#2}
+     \ifdim \wd\@tempboxa > \c@pwidth      % IF longer than one line-2cm:
+         \hbox to\hsize{\hfil{\sc #1}\hfil}
+         \begin{list}{}{\leftmargin\t@bindwidth
+             \rightmargin\t@bindwidth}
+             {\item \footnotesize  #2}
+         \end{list}
+     \else                               % ELSE  center.
+         \hbox to\hsize{\hfil{\sc #1}\hfil}
+         \hbox to\hsize{\hfil{\footnotesize #2}\hfil}
+     \fi                                   % of \ifdim
+   \else                                 % Not a table: a picture
+     \setbox\@tempboxa\hbox{\small{\bf #1}. #2}
+     \ifdim \wd\@tempboxa >\c@pwidth       % IF longer than one line-2cm:
+        \begin{list}{}{\leftmargin\t@bindwidth
+           \rightmargin\t@bindwidth}
+           {\small \item {\bf #1}. #2}
+         \end{list}                        % THEN set as ordinary paragraph.
+     \else                               % ELSE  center.
+         \hbox to\hsize{\hfil\box\@tempboxa\hfil}
+     \fi                                   % of \ifdim
+   \fi                                   % of \if\tablecaptrue
+   }                                     % \@makecaption
 
 %  End of \@makecaption modifications.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -209,53 +209,53 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \renewcommand{\ps@plain}{%
-	\renewcommand{\@oddhead}{{\parbox[b]{\textwidth}{
-				\begin{minipage}{0.5\textwidth}
-					The Evolving Scholar (\printyear)
-				\end{minipage}
-				\begin{minipage}{0.5\textwidth}
-					\scriptsize%
-					\raggedleft http://dx.doi.org/\printdoi
-				\end{minipage}
-				\vspace{1mm}
-				\\
-				% logos are 1cm in height @ 300 ppi
-				\begin{minipage}{0.2\textwidth}
-					\includegraphics[height=1cm]{bmd2023-logo-256x118.png}
-				\end{minipage}
-				\begin{minipage}{0.2\textwidth}
-					\includegraphics[height=1cm]{tu-delft-open-logo-294x118.png}
-				\end{minipage}
-				\begin{minipage}{0.6\textwidth}
-					\scriptsize%
-					\raggedleft \textbf{Bicycle and Motorcycle Dynamics 2023\\%
-						Symposium on the Dynamics and Control of Single Track Vehicles\\%
-						18--20 October 2023, Delft University of Technology, The Netherlands}
-				\end{minipage}
-				\vspace{5mm}
-	}}}%
-	\renewcommand{\@evenhead}{{\hfill\parbox[b]{\textwidth}{
-				\begin{minipage}{0.5\textwidth}
-					Evolving Scholar (\printyear)
-				\end{minipage}
-				\begin{minipage}{0.5\textwidth}
-					\scriptsize%
-					\raggedleft http://dx.doi.org/\printdoi
-				\end{minipage}
-				\vspace{5mm}}}}%
-	\renewcommand{\@oddfoot}{{\parbox[b]{\textwidth}{
-				\scriptsize%
-				\copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
-				on behalf of the authors.\\%
-				ISSN: \printissn
-	}}}%
-	\renewcommand{\@evenfoot}{{\parbox[b]{\textwidth}{
-				\scriptsize%
-				\raggedright
-				\copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
-				on behalf of the authors.\\%
-				ISSN: \printissn
-	}}}%
+  \renewcommand{\@oddhead}{{\parbox[b]{\textwidth}{
+    \begin{minipage}{0.5\textwidth}
+      The Evolving Scholar (\printyear)
+    \end{minipage}
+    \begin{minipage}{0.5\textwidth}
+      \scriptsize%
+      \raggedleft http://dx.doi.org/\printdoi
+    \end{minipage}
+    \vspace{1mm}
+    \\
+    % logos are 1cm in height @ 300 ppi
+    \begin{minipage}{0.2\textwidth}
+      \includegraphics[height=1cm]{bmd2023-logo-256x118.png}
+    \end{minipage}
+    \begin{minipage}{0.2\textwidth}
+      \includegraphics[height=1cm]{tu-delft-open-logo-294x118.png}
+    \end{minipage}
+    \begin{minipage}{0.6\textwidth}
+      \scriptsize%
+      \raggedleft \textbf{Bicycle and Motorcycle Dynamics 2023\\%
+      Symposium on the Dynamics and Control of Single Track Vehicles\\%
+      18--20 October 2023, Delft University of Technology, The Netherlands}
+    \end{minipage}
+    \vspace{5mm}
+  }}}%
+  \renewcommand{\@evenhead}{{\hfill\parbox[b]{\textwidth}{
+    \begin{minipage}{0.5\textwidth}
+      Evolving Scholar (\printyear)
+    \end{minipage}
+    \begin{minipage}{0.5\textwidth}
+      \scriptsize%
+      \raggedleft http://dx.doi.org/\printdoi
+    \end{minipage}
+    \vspace{5mm}}}}%
+  \renewcommand{\@oddfoot}{{\parbox[b]{\textwidth}{
+    \scriptsize%
+    \copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
+    on behalf of the authors.\\%
+    ISSN: \printissn
+}}}%
+  \renewcommand{\@evenfoot}{{\parbox[b]{\textwidth}{
+    \scriptsize%
+    \raggedright
+    \copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
+    on behalf of the authors.\\%
+    ISSN: \printissn
+}}}%
 }
 \renewcommand{\baselinestretch}{0.91}
 

--- a/abstract/bmd2023a.cls
+++ b/abstract/bmd2023a.cls
@@ -55,7 +55,7 @@
 \def\accepteddate#1{\def\@accepteddate{#1}}\newcommand{\printaccepteddate}{\@accepteddate}
 \def\publisheddate#1{\def\@publisheddate{#1}}\newcommand{\printpublisheddate}{\@publisheddate}
 \def\citation#1{\def\@citation{#1}}\newcommand{\printcitation}{\@citation}
-\def\authors#1{\def\@authors{#1}}\newcommand{\printauthors}{\@authors}
+\def\authorfooter#1{\def\@authors{#1}}\newcommand{\printauthors}{\@authors}
 \def\issn#1{\def\@issn{#1}}\newcommand{\printissn}{\@issn}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -79,36 +79,116 @@
 \addtolength{\c@pwidth}{-2\t@bindwidth}
 
 \long\def\@makecaption#1#2{
-   %\vskip 10pt
-   \vskip 0.5ex
-   \iftablecap                           % Is it a table?
-     \setbox\@tempboxa\hbox{#2}
-     \ifdim \wd\@tempboxa > \c@pwidth      % IF longer than one line-2cm:
-         \hbox to\hsize{\hfil{\sc #1}\hfil}
-         \begin{list}{}{\leftmargin\t@bindwidth
-             \rightmargin\t@bindwidth}
-             {\item \footnotesize  #2}
-         \end{list}
-     \else                               % ELSE  center.
-         \hbox to\hsize{\hfil{\sc #1}\hfil}
-         \hbox to\hsize{\hfil{\footnotesize #2}\hfil}
-     \fi                                   % of \ifdim
-   \else                                 % Not a table: a picture
-     \setbox\@tempboxa\hbox{\small{\bf #1}. #2}
-     \ifdim \wd\@tempboxa >\c@pwidth       % IF longer than one line-2cm:
-        \begin{list}{}{\leftmargin\t@bindwidth
-           \rightmargin\t@bindwidth}
-           {\small \item {\bf #1}. #2}
-         \end{list}                        % THEN set as ordinary paragraph.
-     \else                               % ELSE  center.
-         \hbox to\hsize{\hfil\box\@tempboxa\hfil}
-     \fi                                   % of \ifdim
-   \fi                                   % of \if\tablecaptrue
-   }                                     % \@makecaption
+	%\vskip 10pt
+	\vskip 0.5ex
+	\iftablecap                           % Is it a table?
+	\setbox\@tempboxa\hbox{#2}
+	\ifdim \wd\@tempboxa > \c@pwidth      % IF longer than one line-2cm:
+	\hbox to\hsize{\hfil{\sc #1}\hfil}
+	\begin{list}{}{\leftmargin\t@bindwidth
+			\rightmargin\t@bindwidth}
+		{\item \footnotesize  #2}
+	\end{list}
+	\else                               % ELSE  center.
+	\hbox to\hsize{\hfil{\sc #1}\hfil}
+	\hbox to\hsize{\hfil{\footnotesize #2}\hfil}
+	\fi                                   % of \ifdim
+	\else                                 % Not a table: a picture
+	\setbox\@tempboxa\hbox{\small{\bf #1}. #2}
+	\ifdim \wd\@tempboxa >\c@pwidth       % IF longer than one line-2cm:
+	\begin{list}{}{\leftmargin\t@bindwidth
+			\rightmargin\t@bindwidth}
+		{\small \item {\bf #1}. #2}
+	\end{list}                        % THEN set as ordinary paragraph.
+	\else                               % ELSE  center.
+	\hbox to\hsize{\hfil\box\@tempboxa\hfil}
+	\fi                                   % of \ifdim
+	\fi                                   % of \if\tablecaptrue
+}                                     % \@makecaption
 
 %  End of \@makecaption modifications.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% MAKETITLE
+%%
+%% Overwriting \maketitle to prevent floats from slipping above a manually
+%% created title
+%%
+%% CMS, 10.01.2023
+
+%% Authorlist
+%% Print comma-separated authorlist after calling 
+%% /addauthor{authorname}{affiliationID} multiple times
+%% Adapted from: https://tex.stackexchange.com/a/231056 (11.01.2023)
+\newcommand{\printlist}[2][,]{{% Print list
+		% http://tex.stackexchange.com/a/89187/5764
+		\def\listsep{\def\listsep{#1}}% Delayed execution of list separator
+		\renewcommand{\do}[1]{\listsep~##1}%
+		\dolistloop\authorlist}}
+\newcommand{\addauthor}[2]{
+	\listadd{\authorlist}{#1~\textsuperscript{#2}}}
+
+%% Affiliationlist
+%% Print affiliations as a vertical list after calling 
+%% /addaffiliation{affiliationID}{affilationName}{EmailOrchidString} 
+%% multiple times
+%% Adapted from: https://tex.stackexchange.com/a/47352 (11.01.2023)
+\newcommand{\affiliationlist}{}
+\newcommand{\addaffiliation}[3]{
+	\makeatletter
+	\expandafter\def\expandafter\affiliationlist\expandafter{\affiliationlist{}
+		\textsuperscript{#1}~#2:~#3\\}
+	\makeatother}
+
+
+%% Overwrite maketitle
+\renewcommand{\@maketitle}{%
+	
+	\noindent\makebox[\linewidth]{\rule{\textwidth}{1.0pt}}
+	
+	\begin{flushleft}
+		{\fontsize{9pt}{11pt}\selectfont%
+			% Do not edit.
+			Type of the Paper: Extended Abstract
+		}
+	\end{flushleft}
+	
+	\begin{flushleft}
+		{\fontsize{18pt}{20pt}\selectfont%
+			% Replace with your paper title.
+			\@title
+		}
+	\end{flushleft}
+	
+	\begin{flushleft}
+		{\fontsize{10}{12}\selectfont{
+				% Replace with your authors.
+				\printlist{\authorlist}
+			}\\}
+		\vspace{10pt}
+		{\fontsize{8pt}{10pt}\selectfont{
+				% Replace with your affiliations.
+				%\textsuperscript{1} Affiliation 1; email One; ORCID One (if applicable) \\
+				%\textsuperscript{2} Affiliation 2; email Two, ORCID Two (if applicable);
+				%email Three, ORCID Three (if applicable) \\
+				\affiliationlist
+				\textsuperscript{*} corresponding author
+		}}
+	\end{flushleft}
+	
+	\noindent\makebox[\linewidth]{\rule{\textwidth}{0.4pt}}
+	
+	\begin{flushleft}
+		{\fontsize{8pt}{10pt}\selectfont{
+				Name of Editor: \printeditor \\
+				Submitted: \printsubmitteddate \\
+				Accepted: \printaccepteddate \\
+				Published: \printpublisheddate \\
+				Citation: \printcitation
+		}}
+	\end{flushleft}
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% SECTIONS
@@ -129,67 +209,58 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \renewcommand{\ps@plain}{%
-  \renewcommand{\@oddhead}{{\parbox[b]{\textwidth}{
-    \begin{minipage}{0.5\textwidth}
-      The Evolving Scholar (\printyear)
-    \end{minipage}
-    \begin{minipage}{0.5\textwidth}
-      \scriptsize%
-      \raggedleft http://dx.doi.org/\printdoi
-    \end{minipage}
-    \vspace{1mm}
-    \\
-    % logos are 1cm in height @ 300 ppi
-    \begin{minipage}{0.2\textwidth}
-      \includegraphics[height=1cm]{bmd2023-logo-256x118.png}
-    \end{minipage}
-    \begin{minipage}{0.2\textwidth}
-      \includegraphics[height=1cm]{tu-delft-open-logo-294x118.png}
-    \end{minipage}
-    \begin{minipage}{0.6\textwidth}
-      \scriptsize%
-      \raggedleft \textbf{Bicycle and Motorcycle Dynamics 2023\\%
-      Symposium on the Dynamics and Control of Single Track Vehicles\\%
-      18--20 October 2023, Delft University of Technology, The Netherlands}
-    \end{minipage}
-    \vspace{5mm}
-  }}}%
-  \renewcommand{\@evenhead}{{\hfill\parbox[b]{\textwidth}{
-    \begin{minipage}{0.5\textwidth}
-      Evolving Scholar (\printyear)
-    \end{minipage}
-    \begin{minipage}{0.5\textwidth}
-      \scriptsize%
-      \raggedleft http://dx.doi.org/\printdoi
-    \end{minipage}
-    \vspace{5mm}}}}%
-  \renewcommand{\@oddfoot}{{\parbox[b]{\textwidth}{
-    \scriptsize%
-    \copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
-    on behalf of the authors.\\%
-    ISSN: \printissn
-}}}%
-  \renewcommand{\@evenfoot}{{\parbox[b]{\textwidth}{
-    \scriptsize%
-    \raggedright
-    \copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
-    on behalf of the authors.\\%
-    ISSN: \printissn
-}}}%
+	\renewcommand{\@oddhead}{{\parbox[b]{\textwidth}{
+				\begin{minipage}{0.5\textwidth}
+					The Evolving Scholar (\printyear)
+				\end{minipage}
+				\begin{minipage}{0.5\textwidth}
+					\scriptsize%
+					\raggedleft http://dx.doi.org/\printdoi
+				\end{minipage}
+				\vspace{1mm}
+				\\
+				% logos are 1cm in height @ 300 ppi
+				\begin{minipage}{0.2\textwidth}
+					\includegraphics[height=1cm]{bmd2023-logo-256x118.png}
+				\end{minipage}
+				\begin{minipage}{0.2\textwidth}
+					\includegraphics[height=1cm]{tu-delft-open-logo-294x118.png}
+				\end{minipage}
+				\begin{minipage}{0.6\textwidth}
+					\scriptsize%
+					\raggedleft \textbf{Bicycle and Motorcycle Dynamics 2023\\%
+						Symposium on the Dynamics and Control of Single Track Vehicles\\%
+						18--20 October 2023, Delft University of Technology, The Netherlands}
+				\end{minipage}
+				\vspace{5mm}
+	}}}%
+	\renewcommand{\@evenhead}{{\hfill\parbox[b]{\textwidth}{
+				\begin{minipage}{0.5\textwidth}
+					Evolving Scholar (\printyear)
+				\end{minipage}
+				\begin{minipage}{0.5\textwidth}
+					\scriptsize%
+					\raggedleft http://dx.doi.org/\printdoi
+				\end{minipage}
+				\vspace{5mm}}}}%
+	\renewcommand{\@oddfoot}{{\parbox[b]{\textwidth}{
+				\scriptsize%
+				\copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
+				on behalf of the authors.\\%
+				ISSN: \printissn
+	}}}%
+	\renewcommand{\@evenfoot}{{\parbox[b]{\textwidth}{
+				\scriptsize%
+				\raggedright
+				\copyright \printyear \hspace{1mm} \printauthors \hspace{1mm} published by TU Delft OPEN
+				on behalf of the authors.\\%
+				ISSN: \printissn
+	}}}%
 }
 \renewcommand{\baselinestretch}{0.91}
 
-\renewcommand{\maketitle}{%
-    \twocolumn[%
-        \fontsize{50}{60}\fontfamily{phv}\fontseries{b}%
-        \fontshape{sl}\selectfont\headlinecolor
-        \@title
-        \medskip
-        ]%
-}
-
 \AtBeginDocument{%
-  \pagestyle{plain}
+	\pagestyle{plain}
 }
 
 \endinput

--- a/abstract/bmd2023a.cls
+++ b/abstract/bmd2023a.cls
@@ -260,7 +260,7 @@
 \renewcommand{\baselinestretch}{0.91}
 
 \AtBeginDocument{%
-	\pagestyle{plain}
+  \pagestyle{plain}
 }
 
 \endinput


### PR DESCRIPTION
As you suggested, I have moved the title generation to the class file and overwrote /maketitle. This fixes issue #1. Floats do not appear above the title anymore. 

For this some macros to set author and affiliations had to be added and an old maketitle overwrite had to be removed. It seemed like a leftover from a previous template anyways. 

There are definitely more elegant ways to do this, but it works 