### PR TITLE
Removed whitespace between author surname and affiliation superscript

### DIFF
--- a/paper/bmd2023p.cls
+++ b/paper/bmd2023p.cls
@@ -188,8 +188,8 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% SECTIONS
-\renewcommand\section{\@startsection {section}{1}{\z@}{-3.5ex plus -1ex minus-.2ex}{0.2ex}{\normalsize\bf}}
-\renewcommand\subsection{\@startsection {subsection}{1}{\z@}{-3.5ex plus -1ex minus-.2ex}{0.2ex}{\small\bf}}
+\renewcommand\section{\@startsection {section}{1}{\z@}{-3.5ex plus -1ex minus-.2ex}{0.2ex}{\fontsize{11}{13}\bf}}
+\renewcommand\subsection{\@startsection {subsection}{1}{\z@}{-3.5ex plus -1ex minus-.2ex}{0.2ex}{\fontsize{11}{13}\bf}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 

--- a/paper/bmd2023p.cls
+++ b/paper/bmd2023p.cls
@@ -238,7 +238,7 @@
   %% headers
   \renewcommand{\@evenhead}{{\parbox[b]{\textwidth}{
     \begin{minipage}{0.5\textwidth}
-      Evolving Scholar (\printyear)
+      The Evolving Scholar (\printyear)
     \end{minipage}
     \begin{minipage}{0.5\textwidth}
       \scriptsize \raggedleft http://dx.doi.org/\printdoi

--- a/paper/bmd2023p.cls
+++ b/paper/bmd2023p.cls
@@ -123,7 +123,7 @@
 		\renewcommand{\do}[1]{\listsep~##1}%
 		\dolistloop\authorlist}}
 \newcommand{\addauthor}[2]{
-	\listadd{\authorlist}{#1~\textsuperscript{#2}}}
+	\listadd{\authorlist}{#1\textsuperscript{#2}}}
 
 %% Affiliationlist
 %% Print affiliations as a vertical list after calling


### PR DESCRIPTION
Fixes #19.

I think I didn't make myself very clear earlier. That's what I meant. Have look. 

I also changed the section and subsection fontsize to 11 pt as described in the instructions. They are currently set to 10 pt and 8 pt. 